### PR TITLE
introducing a CCI-style mono-repository | add sdl2/2.0.12

### DIFF
--- a/recipes/sdl2/all/CMakeLists.txt
+++ b/recipes/sdl2/all/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper)
+
+include(${CONAN_INSTALL_FOLDER}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+if(UNIX AND NOT APPLE)
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+      add_definitions("-DGBM_BO_USE_CURSOR=2")
+    endif()
+  endif()
+endif()
+
+add_subdirectory(source_subfolder)

--- a/recipes/sdl2/all/conandata.yml
+++ b/recipes/sdl2/all/conandata.yml
@@ -1,0 +1,9 @@
+sources:
+  "2.0.12":
+    url: "https://www.libsdl.org/release/SDL2-2.0.12.tar.gz"
+    sha256: 349268f695c02efbc9b9148a70b85e58cefbbf704abd3e91be654db7f1e2c863
+
+patches:
+  "2.0.12":
+    - patch_file: "patches/0002-sdl_string.patch"
+      base_path: "source_subfolder"

--- a/recipes/sdl2/all/conanfile.py
+++ b/recipes/sdl2/all/conanfile.py
@@ -1,0 +1,334 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+
+class SDL2Conan(ConanFile):
+    name = "sdl2"
+    description = "Access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL, Direct3D and Vulkan"
+    topics = ("sdl2", "audio", "keyboard", "graphics", "opengl")
+    url = "https://github.com/bincrafters/conan-sdl2"
+    homepage = "https://www.libsdl.org"
+    license = "Zlib"
+    exports_sources = ["CMakeLists.txt", "patches/*"]
+    generators = ["cmake", "pkg_config"]
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "directx": [True, False],
+        "alsa": [True, False],
+        "jack": [True, False],
+        "pulse": [True, False],
+        "sndio": [True, False],
+        "nas": [True, False],
+        "esd": [True, False],
+        "arts": [True, False],
+        "x11": [True, False],
+        "xcursor": [True, False],
+        "xinerama": [True, False],
+        "xinput": [True, False],
+        "xrandr": [True, False],
+        "xscrnsaver": [True, False],
+        "xshape": [True, False],
+        "xvm": [True, False],
+        "wayland": [True, False],
+        "directfb": [True, False],
+        "iconv": [True, False],
+        "video_rpi": [True, False],
+        "sdl2main": [True, False],
+        "opengl": [True, False],
+        "opengles": [True, False],
+        "vulkan": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "directx": True,
+        "alsa": True,
+        "jack": True,
+        "pulse": True,
+        "sndio": False,
+        "nas": True,
+        "esd": False,
+        "arts": False,
+        "x11": True,
+        "xcursor": True,
+        "xinerama": True,
+        "xinput": True,
+        "xrandr": True,
+        "xscrnsaver": True,
+        "xshape": True,
+        "xvm": True,
+        "wayland": False,
+        "directfb": False,
+        "iconv": True,
+        "video_rpi": False,
+        "sdl2main": True,
+        "opengl": True,
+        "opengles": True,
+        "vulkan": True
+    }
+
+    _source_subfolder = "source_subfolder"
+    _build_subfolder = "build_subfolder"
+    _cmake = None
+
+    def package_id(self):
+        del self.info.options.sdl2main
+
+    def requirements(self):
+        if self.options.iconv:
+            self.requires("libiconv/1.16")
+
+        if self.settings.os == "Linux" and tools.os_info.is_linux:
+            self.requires("xorg/system")
+            if not tools.which("pkg-config"):
+                self.requires("pkgconf/1.7.3")
+            if self.options.alsa:
+                self.requires("libalsa/1.1.9")
+            if self.options.pulse:
+                self.requires("pulseaudio/13.0@bincrafters/stable")
+            if self.options.opengl:
+                self.requires("opengl/system")
+
+    def system_requirements(self):
+        if self.settings.os == "Linux" and tools.os_info.is_linux:
+            if tools.os_info.with_apt or tools.os_info.with_yum:
+                installer = tools.SystemPackageTool()
+
+                packages = []
+                packages_apt = []
+                packages_yum = []
+
+                packages_apt.append("libgbm-dev")
+                packages_yum.append("gdm-devel")
+
+                if self.options.jack:
+                    packages_apt.append("libjack-dev")
+                    packages_yum.append("jack-audio-connection-kit-devel")
+                if self.options.sndio:
+                    packages_apt.append("libsndio-dev")
+                if self.options.nas:
+                    packages_apt.append("libaudio-dev")
+                    packages_yum.append("nas-devel")
+                if self.options.esd:
+                    packages_apt.append("libesd0-dev")
+                    packages_yum.append("esound-devel")
+                if self.options.arts:
+                    packages_apt.append("artsc0-dev")
+                if self.options.wayland:
+                    packages_apt.extend(["libwayland-dev",
+                                     "wayland-protocols"])
+                    packages_yum.extend(["wayland-devel",
+                                    "wayland-protocols-devel"])
+                if self.options.directfb:
+                    packages_apt.append("libdirectfb-dev")
+
+                if tools.os_info.with_apt:
+                    packages = packages_apt
+                elif tools.os_info.with_yum:
+                    packages = packages_yum
+
+                for package in packages:
+                    installer.install(package)
+
+    def config_options(self):
+        if self.settings.os != "Linux":
+            self.options.remove("alsa")
+            self.options.remove("jack")
+            self.options.remove("pulse")
+            self.options.remove("sndio")
+            self.options.remove("nas")
+            self.options.remove("esd")
+            self.options.remove("arts")
+            self.options.remove("x11")
+            self.options.remove("xcursor")
+            self.options.remove("xinerama")
+            self.options.remove("xinput")
+            self.options.remove("xrandr")
+            self.options.remove("xscrnsaver")
+            self.options.remove("xshape")
+            self.options.remove("xvm")
+            self.options.remove("wayland")
+            self.options.remove("directfb")
+            self.options.remove("video_rpi")
+        if self.settings.os != "Windows":
+            self.options.remove("directx")
+
+    def configure(self):
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+        if self.settings.compiler == "Visual Studio":
+            del self.options.fPIC
+        if self.settings.os == "Macos" and not self.options.iconv:
+            raise ConanInvalidConfiguration("On macOS iconv can't be disabled")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = "SDL2-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+
+        # ensure sdl2-config is created for MinGW
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                              "if(NOT WINDOWS OR CYGWIN)",
+                              "if(NOT WINDOWS OR CYGWIN OR MINGW)")
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                              "if(NOT (WINDOWS OR CYGWIN))",
+                              "if(NOT (WINDOWS OR CYGWIN OR MINGW))")
+        self._build_cmake()
+
+    def _check_pkg_config(self, option, package_name):
+        if option:
+            pkg_config = tools.PkgConfig(package_name)
+            if not pkg_config.provides:
+                raise ConanInvalidConfiguration("package %s is not available" % package_name)
+
+    def _check_dependencies(self):
+        if self.settings.os == "Linux":
+            self._check_pkg_config(self.options.jack, "jack")
+            self._check_pkg_config(self.options.esd, "esound")
+            self._check_pkg_config(self.options.wayland, "wayland-client")
+            self._check_pkg_config(self.options.wayland, "wayland-protocols")
+            self._check_pkg_config(self.options.directfb, "directfb")
+
+    def _configure_cmake(self):
+        if not self._cmake:
+            self._check_dependencies()
+
+            self._cmake = CMake(self)
+            # FIXME: self.install_folder not defined? Neccessary?
+            self._cmake.definitions["CONAN_INSTALL_FOLDER"] = self.install_folder
+            if self.settings.os != "Windows":
+                if not self.options.shared:
+                    self._cmake.definitions["SDL_STATIC_PIC"] = self.options.fPIC
+            if self.settings.compiler == "Visual Studio" and not self.options.shared:
+                self._cmake.definitions["HAVE_LIBC"] = True
+            self._cmake.definitions["SDL_SHARED"] = self.options.shared
+            self._cmake.definitions["SDL_STATIC"] = not self.options.shared
+            self._cmake.definitions["VIDEO_OPENGL"] = self.options.opengl
+            self._cmake.definitions["VIDEO_OPENGLES"] = self.options.opengles
+            self._cmake.definitions["VIDEO_VULKAN"] = self.options.vulkan
+            if self.settings.os == "Linux":
+                # See https://github.com/bincrafters/community/issues/696
+                self._cmake.definitions["SDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS"] = 1
+
+                self._cmake.definitions["ALSA"] = self.options.alsa
+                if self.options.alsa:
+                    self._cmake.definitions["HAVE_ASOUNDLIB_H"] = True
+                    self._cmake.definitions["HAVE_LIBASOUND"] = True
+                self._cmake.definitions["JACK"] = self.options.jack
+                self._cmake.definitions["PULSEAUDIO"] = self.options.pulse
+                self._cmake.definitions["SNDIO"] = self.options.sndio
+                self._cmake.definitions["NAS"] = self.options.nas
+                self._cmake.definitions["VIDEO_X11"] = self.options.x11
+                if self.options.x11:
+                    self._cmake.definitions["HAVE_XEXT_H"] = True
+                self._cmake.definitions["VIDEO_X11_XCURSOR"] = self.options.xcursor
+                if self.options.xcursor:
+                    self._cmake.definitions["HAVE_XCURSOR_H"] = True
+                self._cmake.definitions["VIDEO_X11_XINERAMA"] = self.options.xinerama
+                if self.options.xinerama:
+                    self._cmake.definitions["HAVE_XINERAMA_H"] = True
+                self._cmake.definitions["VIDEO_X11_XINPUT"] = self.options.xinput
+                if self.options.xinput:
+                    self._cmake.definitions["HAVE_XINPUT_H"] = True
+                self._cmake.definitions["VIDEO_X11_XRANDR"] = self.options.xrandr
+                if self.options.xrandr:
+                    self._cmake.definitions["HAVE_XRANDR_H"] = True
+                self._cmake.definitions["VIDEO_X11_XSCRNSAVER"] = self.options.xscrnsaver
+                if self.options.xscrnsaver:
+                    self._cmake.definitions["HAVE_XSS_H"] = True
+                self._cmake.definitions["VIDEO_X11_XSHAPE"] = self.options.xshape
+                if self.options.xshape:
+                    self._cmake.definitions["HAVE_XSHAPE_H"] = True
+                self._cmake.definitions["VIDEO_X11_XVM"] = self.options.xvm
+                if self.options.xvm:
+                    self._cmake.definitions["HAVE_XF86VM_H"] = True
+                self._cmake.definitions["VIDEO_WAYLAND"] = self.options.wayland
+                self._cmake.definitions["VIDEO_DIRECTFB"] = self.options.directfb
+                self._cmake.definitions["VIDEO_RPI"] = self.options.video_rpi
+            elif self.settings.os == "Windows":
+                self._cmake.definitions["DIRECTX"] = self.options.directx
+
+            self._cmake.configure(build_dir=self._build_subfolder)
+        return self._cmake
+
+    def _build_cmake(self):
+        if self.settings.os == "Linux":
+            if self.options.pulse:
+                os.rename("libpulse.pc", "libpulse-simple.pc")
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy(pattern="COPYING.txt", dst="license", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install(build_dir=self._build_subfolder)
+        tools.rmdir(os.path.join(self.package_folder, "cmake"))
+
+    def _add_libraries_from_pc(self, library, static=None):
+        if static is None:
+            static = not self.options.shared
+        pkg_config = tools.PkgConfig(library, static=static)
+        libs = [lib[2:] for lib in pkg_config.libs_only_l]  # cut -l prefix
+        lib_paths = [lib[2:] for lib in pkg_config.libs_only_L]  # cut -L prefix
+        self.cpp_info.libs.extend(libs)
+        self.cpp_info.libdirs.extend(lib_paths)
+        self.cpp_info.sharedlinkflags.extend(pkg_config.libs_only_other)
+        self.cpp_info.exelinkflags.extend(pkg_config.libs_only_other)
+
+    @staticmethod
+    def _chmod_plus_x(filename):
+        if os.name == "posix":
+            os.chmod(filename, os.stat(filename).st_mode | 0o111)
+
+    def package_info(self):
+        sdl2_config = os.path.join(self.package_folder, "bin", "sdl2-config")
+        self._chmod_plus_x(sdl2_config)
+        self.output.info("Creating SDL2_CONFIG environment variable: %s" % sdl2_config)
+        self.env_info.SDL2_CONFIG = sdl2_config
+        self.output.info("Creating SDL_CONFIG environment variable: %s" % sdl2_config)
+        self.env_info.SDL_CONFIG = sdl2_config
+        self.cpp_info.libs = [lib for lib in tools.collect_libs(self) if "2.0" not in lib]
+        if not self.options.sdl2main:
+            self.cpp_info.libs = [lib for lib in self.cpp_info.libs]
+        else:
+            # ensure that SDL2main is linked first
+            sdl2mainlib = "SDL2main"
+            if self.settings.build_type == "Debug":
+                sdl2mainlib = "SDL2maind"
+            self.cpp_info.libs.insert(0, self.cpp_info.libs.pop(self.cpp_info.libs.index(sdl2mainlib)))
+        self.cpp_info.includedirs.append(os.path.join("include", "SDL2"))
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs.extend(["dl", "rt", "pthread"])
+            if self.options.jack:
+                self._add_libraries_from_pc("jack")
+            if self.options.sndio:
+                self._add_libraries_from_pc("sndio")
+            if self.options.nas:
+                self.cpp_info.libs.append("audio")
+            if self.options.esd:
+                self._add_libraries_from_pc("esound")
+            if self.options.directfb:
+                self._add_libraries_from_pc("directfb")
+            if self.options.video_rpi:
+                self.cpp_info.libs.append("bcm_host")
+                self.cpp_info.includedirs.extend(["/opt/vc/include",
+                                                  "/opt/vc/include/interface/vcos/pthreads",
+                                                  "/opt/vc/include/interface/vmcs_host/linux"])
+                self.cpp_info.libdirs.append("/opt/vc/lib")
+                self.cpp_info.sharedlinkflags.append("-Wl,-rpath,/opt/vc/lib")
+                self.cpp_info.exelinkflags.append("-Wl,-rpath,/opt/vc/lib")
+        elif self.settings.os == "Macos":
+            self.cpp_info.frameworks.extend(["Cocoa", "Carbon", "IOKit", "CoreVideo", "CoreAudio", "AudioToolbox", "ForceFeedback"])
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs.extend(["user32", "gdi32", "winmm", "imm32", "ole32", "oleaut32", "version", "uuid", "advapi32", "setupapi", "shell32"])
+            if self.settings.compiler == "gcc":
+                self.cpp_info.system_libs.append("mingw32")
+        self.cpp_info.names["cmake_find_package"] = "SDL2"
+        self.cpp_info.names["cmake_find_package_multi"] = "SDL2"

--- a/recipes/sdl2/all/patches/0002-sdl_string.patch
+++ b/recipes/sdl2/all/patches/0002-sdl_string.patch
@@ -1,0 +1,18 @@
+--- a/src/stdlib/SDL_string.c	2019-07-25 06:32:36.000000000 +0200
++++ b/src/stdlib/SDL_string.c	2019-08-11 14:23:08.406453900 +0200
+@@ -311,6 +311,15 @@
+ #endif /* HAVE_MEMSET */
+ }
+ 
++#if !defined(HAVE_MEMSET)
++#pragma function(memset)
++void *
++memset(void *dst, int c, size_t len)
++{
++    return SDL_memset(dst, c, len);
++}
++#endif /* HAVE_MEMSET */
++
+ void *
+ SDL_memcpy(SDL_OUT_BYTECAP(len) void *dst, SDL_IN_BYTECAP(len) const void *src, size_t len)
+ {

--- a/recipes/sdl2/all/test_package/CMakeLists.txt
+++ b/recipes/sdl2/all/test_package/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+
+function(add_option option)
+    if(${option})
+        target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE "${option}")
+    endif()
+endfunction()
+
+add_option(WITH_X11)
+add_option(WITH_ALSA)
+add_option(WITH_PULSE)
+add_option(WITH_ESD)
+add_option(WITH_ARTS)
+add_option(WITH_DIRECTFB)
+add_option(WITH_DIRECTX)

--- a/recipes/sdl2/all/test_package/conanfile.py
+++ b/recipes/sdl2/all/test_package/conanfile.py
@@ -1,0 +1,29 @@
+from conans import ConanFile, CMake, tools, RunEnvironment
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        self.build_cmake()
+
+    def build_cmake(self):
+        cmake = CMake(self)
+        if self.settings.os == "Linux":
+            cmake.definitions["WITH_X11"] = self.options["sdl2"].x11
+            cmake.definitions["WITH_ALSA"] = self.options["sdl2"].alsa
+            cmake.definitions["WITH_PULSE"] = self.options["sdl2"].pulse
+            cmake.definitions["WITH_ESD"] = self.options["sdl2"].esd
+            cmake.definitions["WITH_ARTS"] = self.options["sdl2"].arts
+            cmake.definitions["WITH_DIRECTFB"] = self.options["sdl2"].directfb
+        if self.settings.os == "Windows":
+            cmake.definitions["WITH_DIRECTX"] = self.options["sdl2"].directx
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/sdl2/all/test_package/test_package.cpp
+++ b/recipes/sdl2/all/test_package/test_package.cpp
@@ -1,0 +1,81 @@
+#include <SDL.h>
+#include <stdexcept>
+#include <string>
+#include <sstream>
+#include <iostream>
+#include <cstdlib>
+
+static void throw_exception(const char * message, const char * name)
+{
+    std::stringstream s;
+    s << message << " - " << name;
+    throw std::runtime_error(s.str().c_str());
+}
+
+static void check_audio_driver(const char * name)
+{
+    std::cout << "checking for audio driver " << name << " ... ";
+    bool found = false;
+    int count = SDL_GetNumAudioDrivers();
+    for (int i = 0; i < count; ++i) {
+        if (0 == strcmp(name, SDL_GetAudioDriver(i))) {
+            found = true;
+            break;
+        }
+    }
+    if (!found)
+        throw_exception("audio driver wasn't found", name);
+    std::cout << "OK!" << std::endl;
+}
+
+static void check_video_driver(const char * name)
+{
+    std::cout << "checking for video driver " << name << " ... ";
+    bool found = false;
+    int count = SDL_GetNumVideoDrivers();
+    for (int i = 0; i < count; ++i) {
+        if (0 == strcmp(name, SDL_GetVideoDriver(i))) {
+            found = true;
+            break;
+        }
+    }
+    if (!found)
+        throw_exception("video driver wasn't found", name);
+    std::cout << "OK!" << std::endl;
+}
+
+
+int main(int argc, char *argv[]) try
+{
+    SDL_version v;
+    SDL_GetVersion(&v);
+    std::cout << "SDL version " << int(v.major) << "." << int(v.minor) << "." << int(v.patch) << std::endl;
+#ifdef WITH_X11
+    check_video_driver("x11");
+#endif
+#ifdef WITH_ALSA
+    check_audio_driver("alsa");
+#endif
+#ifdef WITH_PULSE
+    check_audio_driver("pulseaudio");
+#endif
+#ifdef WITH_ESD
+    check_audio_driver("esd");
+#endif
+#ifdef WITH_ARTS
+    check_audio_driver("arts");
+#endif
+#ifdef WITH_DIRECTFB
+    check_video_driver("directfb");
+#endif
+#ifdef WITH_DIRECTX
+    check_audio_driver("directsound");
+#endif
+    return EXIT_SUCCESS;
+}
+catch (std::runtime_error & e)
+{
+    std::cout << "FAIL!" << std::endl;
+    std::cerr << e.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/recipes/sdl2/config.yml
+++ b/recipes/sdl2/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.0.12":
+    folder: all


### PR DESCRIPTION
Merging our SDL2 recipe from a [standalone repository](https://github.com/bincrafters/conan-sdl2) into a CCI-style mono repository.

Tooling should be so far that I'm daring to open this PR. That said, there are still rough edges that I will ironing out over the next weeks or so.

I would like to continue to contribute to open source Conan mass building tooling, that supports:
  * a repository with just one recipe with one version per branch (every single Bincrafters repository so far)
  * a repository with one recipe, but many versions in a single branch
  * a CCI-style repository with many recipes and many versions in a single branch

I think that for every one of those there is a good use case.

For Bincrafters, having so many repositories is kinda painful.
  * if you update CI config files or if you update meta files like `.gitattributes` or add new ones like `.editorconfig` you have to push those changes into every single repository
  * it is hard to keep track of open pull requests and response to them accordingly
  * people from the outside are regularly confused where to report issues or where the source code is and where to open pull requests
  * if someone from the outside wants to contribute a new recipe versions, they will have to wait until a Bincrafters member is creating a new versioned branch
  * if someone from the outside wants to contribute a new recipe, they will have to wait until a Bincrafters is creating a new repository
  * switching between so many repositories so frequently is distracting 

Hence, I would like to see Bincrafters adopting a mono repository for those recipes which won't be merged tomorrow into CCI — we still have many of those. Except modular Boost that is, the tooling can't handle this, similar to CCI.

