### PR TITLE
sdl2: add components (and fix sdl2main option) + various small fixes

### DIFF
--- a/recipes/sdl2/all/conanfile.py
+++ b/recipes/sdl2/all/conanfile.py
@@ -75,8 +75,36 @@ class SDL2Conan(ConanFile):
     _build_subfolder = "build_subfolder"
     _cmake = None
 
-    def package_id(self):
-        del self.info.options.sdl2main
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+        if self.settings.os != "Linux":
+            del self.options.alsa
+            del self.options.jack
+            del self.options.pulse
+            del self.options.sndio
+            del self.options.nas
+            del self.options.esd
+            del self.options.arts
+            del self.options.x11
+            del self.options.xcursor
+            del self.options.xinerama
+            del self.options.xinput
+            del self.options.xrandr
+            del self.options.xscrnsaver
+            del self.options.xshape
+            del self.options.xvm
+            del self.options.wayland
+            del self.options.directfb
+            del self.options.video_rpi
+        if self.settings.os != "Windows":
+            del self.options.directx
+
+    def configure(self):
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+        if self.settings.os == "Macos" and not self.options.iconv:
+            raise ConanInvalidConfiguration("On macOS iconv can't be disabled")
 
     def requirements(self):
         if self.options.iconv:
@@ -89,6 +117,9 @@ class SDL2Conan(ConanFile):
                 self.requires("pulseaudio/13.0")
             if self.options.opengl:
                 self.requires("opengl/system")
+
+    def package_id(self):
+        del self.info.options.sdl2main
 
     def build_requirements(self):
         if self.settings.os == "Linux":
@@ -134,37 +165,6 @@ class SDL2Conan(ConanFile):
 
                 for package in packages:
                     installer.install(package)
-
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-        if self.settings.os != "Linux":
-            del self.options.alsa
-            del self.options.jack
-            del self.options.pulse
-            del self.options.sndio
-            del self.options.nas
-            del self.options.esd
-            del self.options.arts
-            del self.options.x11
-            del self.options.xcursor
-            del self.options.xinerama
-            del self.options.xinput
-            del self.options.xrandr
-            del self.options.xscrnsaver
-            del self.options.xshape
-            del self.options.xvm
-            del self.options.wayland
-            del self.options.directfb
-            del self.options.video_rpi
-        if self.settings.os != "Windows":
-            del self.options.directx
-
-    def configure(self):
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
-        if self.settings.os == "Macos" and not self.options.iconv:
-            raise ConanInvalidConfiguration("On macOS iconv can't be disabled")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/sdl2/all/conanfile.py
+++ b/recipes/sdl2/all/conanfile.py
@@ -139,26 +139,26 @@ class SDL2Conan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
         if self.settings.os != "Linux":
-            self.options.remove("alsa")
-            self.options.remove("jack")
-            self.options.remove("pulse")
-            self.options.remove("sndio")
-            self.options.remove("nas")
-            self.options.remove("esd")
-            self.options.remove("arts")
-            self.options.remove("x11")
-            self.options.remove("xcursor")
-            self.options.remove("xinerama")
-            self.options.remove("xinput")
-            self.options.remove("xrandr")
-            self.options.remove("xscrnsaver")
-            self.options.remove("xshape")
-            self.options.remove("xvm")
-            self.options.remove("wayland")
-            self.options.remove("directfb")
-            self.options.remove("video_rpi")
+            del self.options.alsa
+            del self.options.jack
+            del self.options.pulse
+            del self.options.sndio
+            del self.options.nas
+            del self.options.esd
+            del self.options.arts
+            del self.options.x11
+            del self.options.xcursor
+            del self.options.xinerama
+            del self.options.xinput
+            del self.options.xrandr
+            del self.options.xscrnsaver
+            del self.options.xshape
+            del self.options.xvm
+            del self.options.wayland
+            del self.options.directfb
+            del self.options.video_rpi
         if self.settings.os != "Windows":
-            self.options.remove("directx")
+            del self.options.directx
 
     def configure(self):
         del self.settings.compiler.libcxx

--- a/recipes/sdl2/all/conanfile.py
+++ b/recipes/sdl2/all/conanfile.py
@@ -291,11 +291,6 @@ class SDL2Conan(ConanFile):
         self.cpp_info.components["libsdl2"].sharedlinkflags.extend(pkg_config.libs_only_other)
         self.cpp_info.components["libsdl2"].exelinkflags.extend(pkg_config.libs_only_other)
 
-    @staticmethod
-    def _chmod_plus_x(filename):
-        if os.name == "posix":
-            os.chmod(filename, os.stat(filename).st_mode | 0o111)
-
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "SDL2"
         self.cpp_info.names["cmake_find_package_multi"] = "SDL2"

--- a/recipes/sdl2/all/conanfile.py
+++ b/recipes/sdl2/all/conanfile.py
@@ -81,7 +81,7 @@ class SDL2Conan(ConanFile):
     def requirements(self):
         if self.options.iconv:
             self.requires("libiconv/1.16")
-        if self.settings.os == "Linux" and tools.os_info.is_linux:
+        if self.settings.os == "Linux":
             self.requires("xorg/system")
             if self.options.alsa:
                 self.requires("libalsa/1.1.9")

--- a/recipes/sdl2/all/conanfile.py
+++ b/recipes/sdl2/all/conanfile.py
@@ -2,6 +2,8 @@ from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
+required_conan_version = ">=1.29.1"
+
 
 class SDL2Conan(ConanFile):
     # TODO: When porting to CCI rename this package to SDL (without 2)
@@ -270,8 +272,13 @@ class SDL2Conan(ConanFile):
     def package(self):
         self.copy(pattern="COPYING.txt", dst="license", src=self._source_subfolder)
         cmake = self._configure_cmake()
-        cmake.install(build_dir=self._build_subfolder)
+        cmake.install()
+        tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "sdl2-config")
         tools.rmdir(os.path.join(self.package_folder, "cmake"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.rmdir(os.path.join(self.package_folder, "libdata"))
+        tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def _add_libraries_from_pc(self, library, static=None):
         if static is None:
@@ -343,10 +350,3 @@ class SDL2Conan(ConanFile):
             self.cpp_info.components["sdl2main"].names["cmake_find_package_multi"] = "SDL2main"
             self.cpp_info.components["sdl2main"].libs = ["SDL2main" + postfix]
             self.cpp_info.components["sdl2main"].requires = ["libsdl2"]
-
-        sdl2_config = os.path.join(self.package_folder, "bin", "sdl2-config")
-        self._chmod_plus_x(sdl2_config)
-        self.output.info("Creating SDL2_CONFIG environment variable: {}".format(sdl2_config))
-        self.env_info.SDL2_CONFIG = sdl2_config
-        self.output.info("Creating SDL_CONFIG environment variable: {}".format(sdl2_config))
-        self.env_info.SDL_CONFIG = sdl2_config

--- a/recipes/sdl2/all/conanfile.py
+++ b/recipes/sdl2/all/conanfile.py
@@ -136,6 +136,8 @@ class SDL2Conan(ConanFile):
                     installer.install(package)
 
     def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
         if self.settings.os != "Linux":
             self.options.remove("alsa")
             self.options.remove("jack")
@@ -161,8 +163,6 @@ class SDL2Conan(ConanFile):
     def configure(self):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
-        if self.settings.compiler == "Visual Studio":
-            del self.options.fPIC
         if self.settings.os == "Macos" and not self.options.iconv:
             raise ConanInvalidConfiguration("On macOS iconv can't be disabled")
 

--- a/recipes/sdl2/all/conanfile.py
+++ b/recipes/sdl2/all/conanfile.py
@@ -81,17 +81,18 @@ class SDL2Conan(ConanFile):
     def requirements(self):
         if self.options.iconv:
             self.requires("libiconv/1.16")
-
         if self.settings.os == "Linux" and tools.os_info.is_linux:
             self.requires("xorg/system")
-            if not tools.which("pkg-config"):
-                self.requires("pkgconf/1.7.3")
             if self.options.alsa:
                 self.requires("libalsa/1.1.9")
             if self.options.pulse:
                 self.requires("pulseaudio/13.0")
             if self.options.opengl:
                 self.requires("opengl/system")
+
+    def build_requirements(self):
+        if self.settings.os == "Linux":
+            self.requires("pkgconf/1.7.3")
 
     def system_requirements(self):
         if self.settings.os == "Linux" and tools.os_info.is_linux:

--- a/recipes/sdl2/all/conanfile.py
+++ b/recipes/sdl2/all/conanfile.py
@@ -123,7 +123,7 @@ class SDL2Conan(ConanFile):
 
     def build_requirements(self):
         if self.settings.os == "Linux":
-            self.requires("pkgconf/1.7.3")
+            self.build_requires("pkgconf/1.7.3")
 
     def system_requirements(self):
         if self.settings.os == "Linux" and tools.os_info.is_linux:

--- a/recipes/sdl2/all/test_package/CMakeLists.txt
+++ b/recipes/sdl2/all/test_package/CMakeLists.txt
@@ -4,8 +4,14 @@ project(test_package)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(SDL2 REQUIRED CONFIG)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+if(SDL2_SHARED)
+  target_link_libraries(${PROJECT_NAME} SDL2::SDL2main SDL2::SDL2)
+else()
+  target_link_libraries(${PROJECT_NAME} SDL2::SDL2main SDL2::SDL2-static)
+endif()
 
 function(add_option option)
     if(${option})

--- a/recipes/sdl2/all/test_package/conanfile.py
+++ b/recipes/sdl2/all/test_package/conanfile.py
@@ -4,13 +4,14 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         self.build_cmake()
 
     def build_cmake(self):
         cmake = CMake(self)
+        cmake.definitions["SDL2_SHARED"] = self.options["sdl2"].shared
         if self.settings.os == "Linux":
             cmake.definitions["WITH_X11"] = self.options["sdl2"].x11
             cmake.definitions["WITH_ALSA"] = self.options["sdl2"].alsa


### PR DESCRIPTION
## Description

- add official SDL2 imported targets for `cmake_find_package[_multi]` generators
- fix sdl2main option
- move pkgconf to build_requirement
- delete fPIC if windows
- reorder methods by order of execution (this recipe deletes a lot of options if not Linux, so it's easier to understand the logic when methods are ordered).

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

closes https://github.com/bincrafters/conan-sdl2/pull/35

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

- allow to use official SDL2 imported targets with `cmake_find_package[_multi]` generators
- avoid to propagate `SDL2main` lib in `package_info()` if `sdl2main=False` (https://github.com/bincrafters/conan-sdl2/pull/35)
- pkgconf is a build_requirement, not a requirement, it's important to fix that for components

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Only tested on Windows, Visual Studio 2019:

`conan create . sdl2/2.0.12@bincrafters/stable -o sdl2:shared=False`
`conan create . sdl2/2.0.12@bincrafters/stable -o sdl2:shared=True`