### PR TITLE
portaudio: Add C++ bindings option (#1327)

### DIFF
--- a/recipes/portaudio/all/conanfile.py
+++ b/recipes/portaudio/all/conanfile.py
@@ -144,6 +144,16 @@ elif xcodebuild -version -sdk macosx10.14 Path >/dev/null 2>&1 ; then
             else:
                 self.copy("*.a", dst="lib", src=os.path.join("lib", ".libs"))
 
+        if self.options.cpp_bindings:
+            if self.options.shared:
+                if self.settings.os == "Macos":
+                    self.copy(pattern="*.dylib", dst="lib", src=os.path.join("bindings/cpp/lib", ".libs"))
+                else:
+                    self.copy(pattern="*.so*", dst="lib", src=os.path.join("bindings/cpp/lib", ".libs"))
+            else:
+                self.copy(pattern="*.a", dst="lib", src=os.path.join("bindings/cpp/lib", ".libs"))
+
+
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/portaudio/all/conanfile.py
+++ b/recipes/portaudio/all/conanfile.py
@@ -118,6 +118,8 @@ elif xcodebuild -version -sdk macosx10.14 Path >/dev/null 2>&1 ; then
     def package(self):
         self.copy("FindPortaudio.cmake", ".", ".")
         self.copy("*.h", dst="include", src=os.path.join(self.sources_folder, "include"))
+        if self.options.cpp_bindings:
+            self.copy("*.hxx", dst="include/portaudiocpp", src=os.path.join(self.sources_folder, "bindings/cpp/include/portaudiocpp"))
         self.copy(pattern="LICENSE*", dst="licenses", src=self.sources_folder,  ignore_case=True, keep_path=False)
 
         if self.settings.os == "Windows":


### PR DESCRIPTION
## Description
Add option 'cpp_bindings' to the portaudio package to build C++ bindings. Parallel builds are disabled (i.e. -j1) when this option is enabled since the build does not support it with this option.

## Related Issue
#1327 portaudio/v190600.20161030

## Motivation and Context
This change adds an option to build C++ bindings for portaudio. The default is false so there are no changes for users unless they enable the option.

## How Has This Been Tested?
This change was tested by building on my system: Macbook Pro 16", macOS 11.1 (Big Sur). This is a minor configuration change so the risk is low for other build configurations.