### PR TITLE
sdl: fix libiconv detection

### DIFF
--- a/recipes/sdl2/all/conanfile.py
+++ b/recipes/sdl2/all/conanfile.py
@@ -341,6 +341,8 @@ class SDL2Conan(ConanFile):
                 self.cpp_info.components["libsdl2"].exelinkflags.append("-Wl,-rpath,/opt/vc/lib")
         elif self.settings.os == "Macos":
             self.cpp_info.components["libsdl2"].frameworks = ["Cocoa", "Carbon", "IOKit", "CoreVideo", "CoreAudio", "AudioToolbox", "ForceFeedback"]
+            if self.version >= "2.0.14":
+                self.cpp_info.components["libsdl2"].frameworks.append("Metal")
         elif self.settings.os == "Windows":
             self.cpp_info.components["libsdl2"].system_libs = ["user32", "gdi32", "winmm", "imm32", "ole32", "oleaut32", "version", "uuid", "advapi32", "setupapi", "shell32"]
             if self.settings.compiler == "gcc":

--- a/recipes/sdl2/all/conanfile.py
+++ b/recipes/sdl2/all/conanfile.py
@@ -184,6 +184,10 @@ class SDL2Conan(ConanFile):
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
                               "if(NOT (WINDOWS OR CYGWIN))",
                               "if(NOT (WINDOWS OR CYGWIN OR MINGW))")
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                              'check_library_exists(c iconv_open "" HAVE_BUILTIN_ICONV)',
+                              '# check_library_exists(c iconv_open "" HAVE_BUILTIN_ICONV)',
+                              strict=False)
         self._build_cmake()
 
     def _check_pkg_config(self, option, package_name):

--- a/recipes/sdl2/all/conanfile.py
+++ b/recipes/sdl2/all/conanfile.py
@@ -270,10 +270,10 @@ class SDL2Conan(ConanFile):
         if self.settings.os == "Linux":
             if self.options.pulse:
                 os.rename("libpulse.pc", "libpulse-simple.pc")
-        with tools.run_environment(self):
-            with tools.environment_append({"LIBRARY_PATH": os.getenv("LD_LIBRARY_PATH")}):
-                cmake = self._configure_cmake()
-                cmake.build()
+        lib_paths = [lib for dep in self.deps_cpp_info.deps for lib in self.deps_cpp_info[dep].lib_paths]
+        with tools.environment_append({"LIBRARY_PATH": os.pathsep.join(lib_paths)}):
+            cmake = self._configure_cmake()
+            cmake.build()
 
     def package(self):
         self.copy(pattern="COPYING.txt", dst="license", src=self._source_subfolder)

--- a/recipes/sdl2/all/conanfile.py
+++ b/recipes/sdl2/all/conanfile.py
@@ -184,10 +184,10 @@ class SDL2Conan(ConanFile):
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
                               "if(NOT (WINDOWS OR CYGWIN))",
                               "if(NOT (WINDOWS OR CYGWIN OR MINGW))")
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                              'check_library_exists(c iconv_open "" HAVE_BUILTIN_ICONV)',
-                              '# check_library_exists(c iconv_open "" HAVE_BUILTIN_ICONV)',
-                              strict=False)
+        if self.version >= "2.0.14":
+            tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                                  'check_library_exists(c iconv_open "" HAVE_BUILTIN_ICONV)',
+                                  '# check_library_exists(c iconv_open "" HAVE_BUILTIN_ICONV)')
         self._build_cmake()
 
     def _check_pkg_config(self, option, package_name):

--- a/recipes/sdl2/all/conanfile.py
+++ b/recipes/sdl2/all/conanfile.py
@@ -266,8 +266,10 @@ class SDL2Conan(ConanFile):
         if self.settings.os == "Linux":
             if self.options.pulse:
                 os.rename("libpulse.pc", "libpulse-simple.pc")
-        cmake = self._configure_cmake()
-        cmake.build()
+        with tools.run_environment(self):
+            with tools.environment_append({"LIBRARY_PATH": os.getenv("LD_LIBRARY_PATH")}):
+                cmake = self._configure_cmake()
+                cmake.build()
 
     def package(self):
         self.copy(pattern="COPYING.txt", dst="license", src=self._source_subfolder)


### PR DESCRIPTION
## Description
This change sets `LIBRARY_PATH` env var so that the linker is able to find libraries provided by conan.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
sdl 2.0.12 searched for the `iconv_open` function in `iconv` library, but the path to iconv was never passed, so libiconv detection failed and iconv was not used, regardless the "iconv" option value.
sdl 2.0.14 added an alternative search for `iconv_open` in `c` library, which succeeds. But the final link of the shared library failed, because of missing `iconv_close`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
