### PR TITLE
sdl2: bump version of libalsa requirement

### DIFF
--- a/recipes/sdl2/all/conanfile.py
+++ b/recipes/sdl2/all/conanfile.py
@@ -114,7 +114,7 @@ class SDL2Conan(ConanFile):
         if self.settings.os == "Linux":
             self.requires("xorg/system")
             if self.options.alsa:
-                self.requires("libalsa/1.1.9")
+                self.requires("libalsa/1.2.4")
             if self.options.pulse:
                 self.requires("pulseaudio/13.0")
             if self.options.opengl:


### PR DESCRIPTION
Bump libalsa version of requirement.

The libalsa version conflicted with version of openal and needed manual overrides.