### PR TITLE
imgui-sfml: fix typo

### DIFF
--- a/recipes/imgui-sfml/all/conandata.yml
+++ b/recipes/imgui-sfml/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "2.1":
     url:
-      "sfml-1.75":
+      "imgui-1.75":
         - url: "https://github.com/eliasdaler/imgui-sfml/archive/v2.1.tar.gz"
           sha256: "16a589cb7219ebe3147b13cfe44e50de315deedf6ca8bd67d4ef91de3a09478e"
         - url: "https://github.com/ocornut/imgui/archive/v1.75.tar.gz"

--- a/recipes/imgui-sfml/all/conanfile.py
+++ b/recipes/imgui-sfml/all/conanfile.py
@@ -55,11 +55,11 @@ class ImguiSfmlConan(ConanFile):
         self.options["sfml"].shared = self.options.shared
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version]["url"]["sfml-{}".format(self.options.imgui_version)][0])
+        tools.get(**self.conan_data["sources"][self.version]["url"]["imgui-{}".format(self.options.imgui_version)][0])
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
 
-        tools.get(**self.conan_data["sources"][self.version]["url"]["sfml-{}".format(self.options.imgui_version)][1])
+        tools.get(**self.conan_data["sources"][self.version]["url"]["imgui-{}".format(self.options.imgui_version)][1])
         extracted_dir = glob.glob("imgui-*")[0]
         os.rename(extracted_dir, self._imgui_subfolder)
 


### PR DESCRIPTION
The outer version is the imgui-sfml version, the inner version should be about the imgui version, not sfml

Sorry, of course you only notice such stuff after it is merged 🙈 