### PR TITLE
imgui-sfml: changed layout of sources (bincrafters#1349)

### DIFF
--- a/recipes/imgui-sfml/all/conandata.yml
+++ b/recipes/imgui-sfml/all/conandata.yml
@@ -1,11 +1,24 @@
 sources:
   "2.1":
-    url:
-      "imgui-1.75":
-        - url: "https://github.com/eliasdaler/imgui-sfml/archive/v2.1.tar.gz"
-          sha256: "16a589cb7219ebe3147b13cfe44e50de315deedf6ca8bd67d4ef91de3a09478e"
-        - url: "https://github.com/ocornut/imgui/archive/v1.75.tar.gz"
-          sha256: "1023227fae4cf9c8032f56afcaea8902e9bfaad6d9094d6e48fb8f3903c7b866"
+    imgui-sfml:
+      url: "https://github.com/eliasdaler/imgui-sfml/archive/v2.1.tar.gz"
+      sha256: "16a589cb7219ebe3147b13cfe44e50de315deedf6ca8bd67d4ef91de3a09478e"
+    imgui:
+      "1.75":
+        url: "https://github.com/ocornut/imgui/archive/v1.75.tar.gz"
+        sha256: "1023227fae4cf9c8032f56afcaea8902e9bfaad6d9094d6e48fb8f3903c7b866"
+      "1.76":
+        url: "https://github.com/ocornut/imgui/archive/v1.76.tar.gz"
+        sha256: "e482dda81330d38c87bd81597cacaa89f05e20ed2c4c4a93a64322e97565f6dc"
+      "1.77":
+        url: "https://github.com/ocornut/imgui/archive/v1.77.tar.gz"
+        sha256: "c0dae830025d4a1a169df97409709f40d9dfa19f8fc96b550052224cbb238fa8"
+      "1.78":
+        url: "https://github.com/ocornut/imgui/archive/v1.78.tar.gz"
+        sha256: "f70bbb17581ee2bd42fda526d9c3dc1a5165f3847ff047483d4d7980e166f9a3"
+      "1.79":
+        url: "https://github.com/ocornut/imgui/archive/v1.79.tar.gz"
+        sha256: "f1908501f6dc6db8a4d572c29259847f6f882684b10488d3a8d2da31744cd0a4"
 patches:
   "2.1":
     - patch_file: "patches/0001-conan-libs.patch"

--- a/recipes/imgui-sfml/all/conandata.yml
+++ b/recipes/imgui-sfml/all/conandata.yml
@@ -4,21 +4,8 @@ sources:
       url: "https://github.com/eliasdaler/imgui-sfml/archive/v2.1.tar.gz"
       sha256: "16a589cb7219ebe3147b13cfe44e50de315deedf6ca8bd67d4ef91de3a09478e"
     imgui:
-      "1.75":
-        url: "https://github.com/ocornut/imgui/archive/v1.75.tar.gz"
-        sha256: "1023227fae4cf9c8032f56afcaea8902e9bfaad6d9094d6e48fb8f3903c7b866"
-      "1.76":
-        url: "https://github.com/ocornut/imgui/archive/v1.76.tar.gz"
-        sha256: "e482dda81330d38c87bd81597cacaa89f05e20ed2c4c4a93a64322e97565f6dc"
-      "1.77":
-        url: "https://github.com/ocornut/imgui/archive/v1.77.tar.gz"
-        sha256: "c0dae830025d4a1a169df97409709f40d9dfa19f8fc96b550052224cbb238fa8"
-      "1.78":
-        url: "https://github.com/ocornut/imgui/archive/v1.78.tar.gz"
-        sha256: "f70bbb17581ee2bd42fda526d9c3dc1a5165f3847ff047483d4d7980e166f9a3"
-      "1.79":
-        url: "https://github.com/ocornut/imgui/archive/v1.79.tar.gz"
-        sha256: "f1908501f6dc6db8a4d572c29259847f6f882684b10488d3a8d2da31744cd0a4"
+      url: "https://github.com/ocornut/imgui/archive/v1.79.tar.gz"
+      sha256: "f1908501f6dc6db8a4d572c29259847f6f882684b10488d3a8d2da31744cd0a4"
 patches:
   "2.1":
     - patch_file: "patches/0001-conan-libs.patch"

--- a/recipes/imgui-sfml/all/conanfile.py
+++ b/recipes/imgui-sfml/all/conanfile.py
@@ -20,16 +20,16 @@ class ImguiSfmlConan(ConanFile):
         "fPIC": [True, False],
         "imconfig": "ANY",
         "imconfig_install_folder": "ANY",
-        "imgui_version": ["1.75",],
+        "imgui_version": ["1.75", "1.76", "1.77", "1.78", "1.79",],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "imconfig": None,
         "imconfig_install_folder": None,
+        "imgui_version": "1.79",
         "sfml:window": True,
         "sfml:graphics": True,
-        "imgui_version": "1.75",
     }
 
     _source_subfolder = "source_subfolder"
@@ -55,11 +55,11 @@ class ImguiSfmlConan(ConanFile):
         self.options["sfml"].shared = self.options.shared
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version]["url"]["imgui-{}".format(self.options.imgui_version)][0])
+        tools.get(**self.conan_data["sources"][self.version]["imgui-sfml"])
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
 
-        tools.get(**self.conan_data["sources"][self.version]["url"]["imgui-{}".format(self.options.imgui_version)][1])
+        tools.get(**self.conan_data["sources"][self.version]["imgui"][str(self.options.imgui_version)])
         extracted_dir = glob.glob("imgui-*")[0]
         os.rename(extracted_dir, self._imgui_subfolder)
 

--- a/recipes/imgui-sfml/all/conanfile.py
+++ b/recipes/imgui-sfml/all/conanfile.py
@@ -20,14 +20,12 @@ class ImguiSfmlConan(ConanFile):
         "fPIC": [True, False],
         "imconfig": "ANY",
         "imconfig_install_folder": "ANY",
-        "imgui_version": ["1.75", "1.76", "1.77", "1.78", "1.79",],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "imconfig": None,
         "imconfig_install_folder": None,
-        "imgui_version": "1.79",
         "sfml:window": True,
         "sfml:graphics": True,
     }
@@ -59,7 +57,7 @@ class ImguiSfmlConan(ConanFile):
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
 
-        tools.get(**self.conan_data["sources"][self.version]["imgui"][str(self.options.imgui_version)])
+        tools.get(**self.conan_data["sources"][self.version]["imgui"])
         extracted_dir = glob.glob("imgui-*")[0]
         os.rename(extracted_dir, self._imgui_subfolder)
 


### PR DESCRIPTION
- The layout of the conandata.yml is changed so that it reflects better which sources we are accessing.
- Supported Dear ImGui versions from 1.75 through 1.79. Unfortunately, imgui-sfml 2.1 is not compatible with Dear ImGui v1.80

## Description
<!--- Describe your changes in detail -->
The main changes are in the `conandata.yml` file. It's been modified to allow better access to the sources, and also adding sources for Dear ImGui versions from 1.75 up to 1,79.

The `conanfile.py` file has been adapted to the changes of the `conandata.yml` file. It also adds the versions to the `imgui_version` options and change the default option to 1.79.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1349 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Until now, there was no way of changing the Dear ImGui version to a more recent one. The package was stuck in version 1.75, and the most recent one is 1.80.

For that reason, an option is needed to allow the configuration of the version and not rely in an older one. This way, the user can select the specific version through the `imgui_version` option.

The layout was changed to better reflect the distribution of the sources.

Unfortunately, imgui-sfml 2.1 is not compatible with Dear ImGui v1.80, as this last version includes a new file, `imgui_tables.cpp`, which was not considered for imgui-sfml 2.1. For that reason, imgui-sfml 2.1 refuses to build with Dear ImGui v1.80. The trunk version of imgui-sfml does support v1.80, but we have to wait until a new version is released.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The specs where the changes have been tested are:
**OS**: Ubuntu 16.04 LTS
**Conan version**: 1.33.0
**Python version**: 3.8.3
**CMake version**: 3.19.3
**Hooks**: conan-center
