### PR TITLE
Update imgui-sfml to version 2.2

### DIFF
--- a/recipes/imgui-sfml/all/conandata.yml
+++ b/recipes/imgui-sfml/all/conandata.yml
@@ -13,6 +13,13 @@ sources:
     imgui:
       url: "https://github.com/ocornut/imgui/archive/v1.81.tar.gz"
       sha256: "f7c619e03a06c0f25e8f47262dbc32d61fd033d2c91796812bf0f8c94fca78fb"
+  "f35da327e79a00a9b3514fc5ff4de52456f78961":
+    imgui-sfml:
+      url: "https://github.com/eliasdaler/imgui-sfml/archive/f35da327e79a00a9b3514fc5ff4de52456f78961.zip"
+      sha256: "042c75df691834b22bbd9a5d310e4df706ec763576703f2f2d2082dbd5e4dc38"
+    imgui:
+      url: "https://github.com/ocornut/imgui/archive/v1.81.tar.gz"
+      sha256: "f7c619e03a06c0f25e8f47262dbc32d61fd033d2c91796812bf0f8c94fca78fb"
 patches:
   "2.1":
     - patch_file: "patches/0001-conan-libs.patch"

--- a/recipes/imgui-sfml/all/conandata.yml
+++ b/recipes/imgui-sfml/all/conandata.yml
@@ -13,20 +13,10 @@ sources:
     imgui:
       url: "https://github.com/ocornut/imgui/archive/v1.81.tar.gz"
       sha256: "f7c619e03a06c0f25e8f47262dbc32d61fd033d2c91796812bf0f8c94fca78fb"
-  "2.3":
-    imgui-sfml:
-      url: "https://github.com/eliasdaler/imgui-sfml/archive/v2.3.tar.gz"
-      sha256: "4e2f520916d1d676a4553f5c266ed869e32808b0f4681b9b603280257323a45b"
-    imgui:
-      url: "https://github.com/ocornut/imgui/archive/v1.83.tar.gz"
-      sha256: "ccf3e54b8d1fa30dd35682fc4f50f5d2fe340b8e29e08de71287d0452d8cc3ff"
 patches:
   "2.1":
     - patch_file: "patches/0001-conan-libs.patch"
       base_path: "source_subfolder"
   "2.2":
-    - patch_file: "patches/0001-conan-libs-2.2.patch"
-      base_path: "source_subfolder"
-  "2.3":
     - patch_file: "patches/0001-conan-libs-2.2.patch"
       base_path: "source_subfolder"

--- a/recipes/imgui-sfml/all/conandata.yml
+++ b/recipes/imgui-sfml/all/conandata.yml
@@ -24,3 +24,6 @@ patches:
   "2.1":
     - patch_file: "patches/0001-conan-libs.patch"
       base_path: "source_subfolder"
+  "2.2":
+    - patch_file: "patches/0001-conan-libs-2.2.patch"
+      base_path: "source_subfolder"

--- a/recipes/imgui-sfml/all/conandata.yml
+++ b/recipes/imgui-sfml/all/conandata.yml
@@ -13,17 +13,20 @@ sources:
     imgui:
       url: "https://github.com/ocornut/imgui/archive/v1.81.tar.gz"
       sha256: "f7c619e03a06c0f25e8f47262dbc32d61fd033d2c91796812bf0f8c94fca78fb"
-  "f35da327e79a00a9b3514fc5ff4de52456f78961":
+  "2.3":
     imgui-sfml:
-      url: "https://github.com/eliasdaler/imgui-sfml/archive/f35da327e79a00a9b3514fc5ff4de52456f78961.zip"
-      sha256: "042c75df691834b22bbd9a5d310e4df706ec763576703f2f2d2082dbd5e4dc38"
+      url: "https://github.com/eliasdaler/imgui-sfml/archive/v2.3.tar.gz"
+      sha256: "4e2f520916d1d676a4553f5c266ed869e32808b0f4681b9b603280257323a45b"
     imgui:
-      url: "https://github.com/ocornut/imgui/archive/v1.81.tar.gz"
-      sha256: "f7c619e03a06c0f25e8f47262dbc32d61fd033d2c91796812bf0f8c94fca78fb"
+      url: "https://github.com/ocornut/imgui/archive/v1.83.tar.gz"
+      sha256: "ccf3e54b8d1fa30dd35682fc4f50f5d2fe340b8e29e08de71287d0452d8cc3ff"
 patches:
   "2.1":
     - patch_file: "patches/0001-conan-libs.patch"
       base_path: "source_subfolder"
   "2.2":
+    - patch_file: "patches/0001-conan-libs-2.2.patch"
+      base_path: "source_subfolder"
+  "2.3":
     - patch_file: "patches/0001-conan-libs-2.2.patch"
       base_path: "source_subfolder"

--- a/recipes/imgui-sfml/all/conandata.yml
+++ b/recipes/imgui-sfml/all/conandata.yml
@@ -6,6 +6,13 @@ sources:
     imgui:
       url: "https://github.com/ocornut/imgui/archive/v1.79.tar.gz"
       sha256: "f1908501f6dc6db8a4d572c29259847f6f882684b10488d3a8d2da31744cd0a4"
+  "2.2":
+    imgui-sfml:
+      url: "https://github.com/eliasdaler/imgui-sfml/archive/v2.2.tar.gz"
+      sha256: "843536a6c558579ab57f749c4c6e1e67e0f7b033ab434e0f9cf1ad38726ac51e"
+    imgui:
+      url: "https://github.com/ocornut/imgui/archive/v1.81.tar.gz"
+      sha256: "f7c619e03a06c0f25e8f47262dbc32d61fd033d2c91796812bf0f8c94fca78fb"
 patches:
   "2.1":
     - patch_file: "patches/0001-conan-libs.patch"

--- a/recipes/imgui-sfml/all/conanfile.py
+++ b/recipes/imgui-sfml/all/conanfile.py
@@ -20,12 +20,14 @@ class ImguiSfmlConan(ConanFile):
         "fPIC": [True, False],
         "imconfig": "ANY",
         "imconfig_install_folder": "ANY",
+        "imgui_demo": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "imconfig": None,
         "imconfig_install_folder": None,
+        "imgui_demo": False,
         "sfml:window": True,
         "sfml:graphics": True,
     }
@@ -66,6 +68,8 @@ class ImguiSfmlConan(ConanFile):
         cmake.definitions["IMGUI_DIR"] = os.path.join(self.source_folder, self._imgui_subfolder)
         cmake.definitions["IMGUI_SFML_BUILD_EXAMPLES"] = "OFF"
         cmake.definitions["IMGUI_SFML_FIND_SFML"] = "OFF"
+        if self.options.imgui_demo:
+            cmake.definitions["IMGUI_SFML_IMGUI_DEMO"] = "ON"
         if self.options.imconfig_install_folder:
             cmake.definitions["IMGUI_SFML_CONFIG_INSTALL_DIR"] = self.options.imconfig_install_folder
         if self.options.imconfig:

--- a/recipes/imgui-sfml/all/patches/0001-conan-libs-2.2.patch
+++ b/recipes/imgui-sfml/all/patches/0001-conan-libs-2.2.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 53500fd..902017c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -93,12 +93,12 @@ add_library(ImGui-SFML::ImGui-SFML ALIAS ImGui-SFML)
+ 
+ target_link_libraries(ImGui-SFML
+   PUBLIC
+-    sfml-graphics
+-    sfml-system
+-    sfml-window
++    ${CONAN_LIBS}
+     ${OPENGL_LIBRARIES}
+ )
+ 
++target_compile_features(ImGui-SFML PUBLIC cxx_std_11)
++
+ include(GNUInstallDirs)
+ 
+ target_include_directories(ImGui-SFML

--- a/recipes/imgui-sfml/config.yml
+++ b/recipes/imgui-sfml/config.yml
@@ -1,3 +1,5 @@
 versions:
   "2.1":
     folder: all
+  "2.2":
+    folder: all

--- a/recipes/imgui-sfml/config.yml
+++ b/recipes/imgui-sfml/config.yml
@@ -3,5 +3,5 @@ versions:
     folder: all
   "2.2":
     folder: all
-  "f35da327e79a00a9b3514fc5ff4de52456f78961":
+  "2.3":
     folder: all

--- a/recipes/imgui-sfml/config.yml
+++ b/recipes/imgui-sfml/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "2.2":
     folder: all
+  "f35da327e79a00a9b3514fc5ff4de52456f78961":
+    folder: all

--- a/recipes/imgui-sfml/config.yml
+++ b/recipes/imgui-sfml/config.yml
@@ -3,5 +3,3 @@ versions:
     folder: all
   "2.2":
     folder: all
-  "2.3":
-    folder: all


### PR DESCRIPTION
## Description
Basically updating to the new version og ImGui-SFML:
- Bump imgui-sfml version to 2.2.
- Using last version of Dear ImGui (v1.81).
- Added the option `imgui_demo`, so the user can decide to build the demo for Dear ImGui.

## Related Issue


## Motivation and Context
The new version of ImGui-SFML comes with a few changes that are necessary to keep up-to-date with Dear ImGui and also fixes some bugs.

## How Has This Been Tested?
OS: Ubuntu 16.04 LTS
Conan version: 1.33.1
Python version: 3.8.3
CMake version: 3.19.5
Hooks: conan-center
