### PR TITLE
Bump Crashpad version

### DIFF
--- a/recipes/crashpad/all/conanfile.py
+++ b/recipes/crashpad/all/conanfile.py
@@ -24,7 +24,7 @@ class CrashpadConan(ConanFile):
     short_paths = True
     generators = "compiler_args"
 
-    _commit_id = "c7d1d2a1dd7cf2442cbb8aa8da7348fa01d54182"
+    _commit_id = "a8ff626764665101b442be7abfc0a706c4499abf"
     _source_dir = "crashpad"
     _build_name = "out/Conan"
     _build_dir = os.path.join(_source_dir, _build_name)

--- a/recipes/crashpad/config.yml
+++ b/recipes/crashpad/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "20200508":
+  "20200518":
     folder: all


### PR DESCRIPTION
## Description
Bump Crashpad commit hash from c7d1d2a1dd7cf2442cbb8aa8da7348fa01d54182 to a8ff626764665101b442be7abfc0a706c4499abf. This is the next commit and the purpose of the change is to trigger the infrastructure to get the crashpad recipe into the artifactory repo https://bincrafters.jfrog.io/.

Note that https://github.com/bincrafters/conan-crashpad/pull/13 came in late and thus neither `conan-legacy-bincrafters` nor `conan` contains the change in https://bincrafters.jfrog.io/.
