### PR TITLE
Fix building wxwidgets on windows with gcc

### DIFF
--- a/recipes/wxwidgets/all/conanfile.py
+++ b/recipes/wxwidgets/all/conanfile.py
@@ -399,6 +399,7 @@ class wxWidgetsConan(ConanFile):
                                        'comctl32',
                                        'ole32',
                                        'oleaut32',
+                                       'imm32',
                                        'uuid',
                                        'wininet',
                                        'rpcrt4',

--- a/recipes/wxwidgets/all/conanfile.py
+++ b/recipes/wxwidgets/all/conanfile.py
@@ -268,10 +268,15 @@ class wxWidgetsConan(ConanFile):
             version = ''
             suffix = version_suffix_major_minor
         elif self.settings.os == 'Windows':
-            prefix = 'wx'
             toolkit = 'msw'
-            version = '%s%s' % (version_major, version_minor)
-            suffix = ''
+            if self.settings.compiler == 'Visual Studio':
+                prefix = 'wx'
+                version = '%s%s' % (version_major, version_minor)
+                suffix = ''
+            else:
+                prefix = 'wx_'
+                version = ''
+                suffix = version_suffix_major_minor
 
         def base_library_pattern(library):
             return '{prefix}base{version}{unicode}{debug}_%s{suffix}' % library
@@ -281,7 +286,8 @@ class wxWidgetsConan(ConanFile):
 
         libs = []
         if not self.options.shared:
-            libs.append('wxregex{unicode}{debug}{suffix}')
+            regex_suffix = '{debug}' if self.settings.os == "Windows" else '{suffix}'
+            libs.append('wxregex{unicode}' + regex_suffix)
         libs.append('{prefix}base{version}{unicode}{debug}{suffix}')
         libs.append(library_pattern('core'))
         libs.append(library_pattern('adv'))
@@ -408,5 +414,5 @@ class wxWidgetsConan(ConanFile):
         if self.settings.compiler == 'Visual Studio':
             self.cpp_info.includedirs.append(os.path.join('include', 'msvc'))
         else:
-            unix_include_path = os.path.join("include", "wx{}".format(version_suffix_major_minor))
-            self.cpp_info.includedirs = [unix_include_path] + self.cpp_info.includedirs
+            include_path = os.path.join("include", "wx{}".format(version_suffix_major_minor))
+            self.cpp_info.includedirs = [include_path] + self.cpp_info.includedirs

--- a/recipes/wxwidgets/all/conanfile.py
+++ b/recipes/wxwidgets/all/conanfile.py
@@ -407,6 +407,6 @@ class wxWidgetsConan(ConanFile):
                                            'oleacc'])
         if self.settings.compiler == 'Visual Studio':
             self.cpp_info.includedirs.append(os.path.join('include', 'msvc'))
-        elif self.settings.os != 'Windows':
+        else:
             unix_include_path = os.path.join("include", "wx{}".format(version_suffix_major_minor))
             self.cpp_info.includedirs = [unix_include_path] + self.cpp_info.includedirs


### PR DESCRIPTION
## Description
- Change the include path according to [wxWidgets/.../install.cmake](https://github.com/wxWidgets/wxWidgets/blob/v3.1.4/build/cmake/install.cmake#L15).
- Change library prefix and suffix according to [wxWidgets/.../functions.cmake](https://github.com/wxWidgets/wxWidgets/blob/v3.1.4/build/cmake/functions.cmake#L151).
- Add `imm32` windows library required for scintilla.

## Related Issue

- fixes #1402 

## Motivation and Context

The current recipe assumes that when building on (or for) windows, you are using Visual Studio. However wxWidgets' cmake setup [clearly makes a distinction for when building with Visual Studio vs other compilers](https://github.com/wxWidgets/wxWidgets/blob/v3.1.4/build/cmake/functions.cmake#L151). I noticed this issue when cross compiling from Linux (Ubuntu 20.04) to Windows, but it is still valid if you are just building on windows with mingw.

## How Has This Been Tested?

By creating a docker container based on `conanio/gcc8` and adding `mingw-w64` on top. Then creating a conan profile and cmake toolchain to build a demo app. See the script for details:

<details><summary>Click to expand script</summary>

**On host:**
```bash
mkdir demo && cd demo

cat << EOF > Dockerfile
FROM conanio/gcc8:latest

USER root

RUN true \
  && apt-get update \
  && apt-get install -y \
    mingw-w64
EOF
docker build -t conan_win .
docker run -it --user root conan_win bash
```

**In docker:**
```bash
mkdir ~/.conan/profiles
cat << EOF > ~/.conan/profiles/windows
toolchain=/usr/x86_64-w64-mingw32
target_host=x86_64-w64-mingw32
cc_compiler=gcc-posix
cxx_compiler=g++-posix

[env]
CONAN_CMAKE_GENERATOR="Unix Makefiles"
CHOST=\$target_host
AR=\$target_host-ar
AS=\$target_host-as-posix
RANLIB=\$target_host-ranlib
CC=\$target_host-\$cc_compiler
CXX=\$target_host-\$cxx_compiler
STRIP=\$target_host-strip-posix
RC=\$target_host-windres

[settings]
os=Windows
arch=x86_64
compiler=gcc
compiler.version=7.3
compiler.libcxx=libstdc++11
build_type=Release
EOF

git clone https://github.com/Rapatas/community --branch fix/wxwidgets-windows-gcc
cd community/recipes/wxwidgets/all
conan create --options wxwidgets:webview=False --profile windows . wxwidgets/3.1.4@demo/demo
# Wait a bit...
cd ../../../..

cat << EOF > conanfile.py
from conans import ConanFile

class DemoConan(ConanFile):
    generators = [
        "cmake_find_package",
        "cmake_paths"
    ]
    requires = [
        "wxwidgets/3.1.4@demo/demo",
    ]
    default_options = {
        "wxwidgets:webview": False,
    }
EOF

cat << EOF > toolchain.cmake
set(CMAKE_SYSTEM_NAME Windows)
set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)
set(CMAKE_C_COMPILER       \${TOOLCHAIN_PREFIX}-gcc-posix)
set(CMAKE_CXX_COMPILER     \${TOOLCHAIN_PREFIX}-g++-posix)
set(CMAKE_Fortran_COMPILER \${TOOLCHAIN_PREFIX}-gfortran)
set(CMAKE_RC_COMPILER      \${TOOLCHAIN_PREFIX}-windres)
set(CMAKE_FIND_ROOT_PATH /usr/\${TOOLCHAIN_PREFIX})
set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
set(CMAKE_CXX_LINK_FLAGS "\${CMAKE_CXX_LINK_FLAGS} -static -static-libstdc++")
set(CMAKE_C_LINK_FLAGS   "\${CMAKE_C_LINK_FLAGS}   -static -static-libgcc")
EOF

cat << EOF > CMakeLists.txt
cmake_minimum_required(VERSION 3.5)
project(demo)
add_executable(
  \${PROJECT_NAME}
  main.cpp
)
find_package(wxwidgets REQUIRED)
target_link_libraries(
  \${CMAKE_PROJECT_NAME}
  PRIVATE
    wxwidgets::wxwidgets
)
EOF

cat << EOF > main.cpp
#include <wx/wx.h>
int main() { return 0; }
EOF

mkdir build && cd build
conan install --profile windows ../ --build=missing
cmake -DCMAKE_TOOLCHAIN_FILE=../toolchain.cmake -DCMAKE_MODULE_PATH=$PWD -DCMAKE_BUILD_TYPE=Release ..
make

```
_I have disabled the webview dependency since it was broken before I made my changes._
</details>

