### PR TITLE
Portaudio 19.7.0 fixes: invalid device error and mingw gcc build

### DIFF
--- a/recipes/portaudio/19.7.0/conanfile.py
+++ b/recipes/portaudio/19.7.0/conanfile.py
@@ -75,9 +75,10 @@ class PortaudioConan(ConanFile):
             self._cmake = CMake(self)
             self._cmake.definitions["PA_BUILD_STATIC"] = not self.options.shared
             self._cmake.definitions["PA_BUILD_SHARED"] = self.options.shared
-            if self.options.get_safe("with_jack", False):
-                self._cmake.definitions["PA_USE_JACK"] = True
-            if self.options.get_safe("with_alsa", False):
+            self._cmake.definitions["PA_USE_JACK"] = self.options.get_safe("with_jack", False)
+            if self.options.get_safe("with_alsa", False): # with_alsa=False just makes portaudio use the Linux distro's alsa
+                                                          # as a workaround to the fact that conancenter's alsa does not work,
+                                                          # at least some of the time (no devices detected by portaudio)
                 self._cmake.definitions["PA_USE_ALSA"] = True
             self._cmake.configure()
         return self._cmake

--- a/recipes/portaudio/19.7.0/conanfile.py
+++ b/recipes/portaudio/19.7.0/conanfile.py
@@ -55,10 +55,12 @@ class PortaudioConan(ConanFile):
         if self.settings.os == "Linux":
             if tools.os_info.with_apt:
                 installer = tools.SystemPackageTool()
+                installer.install("libasound2-dev") 
                 if self.options.with_jack:
                     installer.install("libjack-dev")
             elif tools.os_info.with_yum:
                 installer = tools.SystemPackageTool()
+                installer.install("alsa-lib-devel")
                 if self.settings.arch == "x86" and tools.detected_architecture() == "x86_64":
                     installer.install("glibmm24.i686")
                     installer.install("glibc-devel.i686")

--- a/recipes/portaudio/19.7.0/conanfile.py
+++ b/recipes/portaudio/19.7.0/conanfile.py
@@ -100,7 +100,7 @@ class PortaudioConan(ConanFile):
             self.cpp_info.frameworks.extend(["CoreAudio", "AudioToolbox", "AudioUnit", "CoreServices", "Carbon"])
 
         if self.settings.os == "Windows" and self.settings.compiler == "gcc" and not self.options.shared:
-            self.cpp_info.system_libs.append("winmm")
+            self.cpp_info.system_libs.extend(["winmm", "setupapi"])
 
         if self.settings.os == "Linux" and not self.options.shared:
             self.cpp_info.system_libs.extend(["m", "pthread", "asound"])

--- a/recipes/portaudio/19.7.0/conanfile.py
+++ b/recipes/portaudio/19.7.0/conanfile.py
@@ -25,8 +25,8 @@ class PortaudioConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_alsa": True,
-        "with_jack": True
+        "with_alsa": False,
+        "with_jack": False
     }
 
     _source_subfolder = "source_subfolder"
@@ -73,8 +73,10 @@ class PortaudioConan(ConanFile):
             self._cmake = CMake(self)
             self._cmake.definitions["PA_BUILD_STATIC"] = not self.options.shared
             self._cmake.definitions["PA_BUILD_SHARED"] = self.options.shared
-            self._cmake.definitions["PA_USE_JACK"] = self.options.get_safe("with_jack", False)
-            self._cmake.definitions["PA_USE_ALSA"] = self.options.get_safe("with_alsa", False)
+            if self.options.get_safe("with_jack", False):
+                self._cmake.definitions["PA_USE_JACK"] = True
+            if self.options.get_safe("with_alsa", False):
+                self._cmake.definitions["PA_USE_ALSA"] = True
             self._cmake.configure()
         return self._cmake
 
@@ -101,6 +103,6 @@ class PortaudioConan(ConanFile):
             self.cpp_info.system_libs.append("winmm")
 
         if self.settings.os == "Linux" and not self.options.shared:
-            self.cpp_info.system_libs.extend(["m", "pthread"])
+            self.cpp_info.system_libs.extend(["m", "pthread", "asound"])
             if self.options.with_jack:
                 self.cpp_info.system_libs.append("jack")


### PR DESCRIPTION
Hi everyone,

The packaged portaudio library (version 19.7.0) was not working with my programs on Linux (tried on Debian, Ubuntu and Fedora). Pa_OpenStream would fail to open a stream, reporting an invalid device error. I have noticed that the difference of the package from a simple portaudio cmake build (which works for me without issue) was that the package's conanfile.py was always passing PA_USE_JACK and PA_USE_ALSA definitions to cmake and, on top of that, those were set to true by default. But the code in portaudio's CMakeLists.txt file (the one that comes with the original library)  can detect support for alsa and jack and "decide" on its own whether to use them, when no definitions are passed, for example: 
```
FIND_PACKAGE(Jack)
    IF(JACK_FOUND)
      OPTION(PA_USE_JACK "Enable support for Jack" ON)
    ELSE()
      OPTION(PA_USE_JACK "Enable support for Jack" OFF)
ENDIF()
```
The only way to get the package to work with my programs on Linux was to re-enable this possibility, by only passing PA_USE_JACK and PA_USE_ALSA if the corresponding package options are set to true:
```
 if self.options.get_safe("with_jack", False):
    self._cmake.definitions["PA_USE_JACK"] = True
 if self.options.get_safe("with_alsa", False):
    self._cmake.definitions["PA_USE_ALSA"] = True
```
So now portaudio has stopped producing the invalid device error on my machines, while the package still provides the possibility to enable jack for example, if a developer so chooses.

I am also linking to setupapi for windows gcc builds (mingw), because I have had some undefined symbols there.

Finally, I am also linking to and deploying the alsa library. On actual linux machines it is usually there already, but it may be missing from some online CI environment images. It was not deployed by default on an appveyor image I am using for example. 

I don't know if you find these changes acceptable, but I thought to at least share them with you. I have tested them on the three linux distributions I have mentioned above and they have resolved the issues I have had. Also, here are some builds of a little game I have put together, which uses this new version of the portaudio package: https://ci.appveyor.com/project/dimi309/gloom-game-conan/builds/40999713 
You can also see the mingw build working well there.
