### PR TITLE
Conan2 recipe for wxWidgets v3.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ venv.bak/
 
 # scons build files
 *.dblite
+
+# CMake user presets
+CMakeUserPresets.json

--- a/recipes/wxwidgets/3.2.1/conandata.yml
+++ b/recipes/wxwidgets/3.2.1/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.2.1":
+    url: "https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.1/wxWidgets-3.2.1.tar.bz2"
+    sha1: "b5299275abddc7cb5fa92f75c17475ade3bc0532"

--- a/recipes/wxwidgets/3.2.1/conanfile.py
+++ b/recipes/wxwidgets/3.2.1/conanfile.py
@@ -16,6 +16,79 @@ class wxWidgetsConan(ConanFile):
     generators = "CMakeDeps", "CMakeToolchain"
     settings = "os", "arch", "compiler", "build_type"
 
+    options = {"shared": [True, False],
+               "fPIC": [True, False],
+               "unicode": [True, False],
+               "compatibility": ["2.8", "3.0", "3.1"],
+               "zlib": ["off", "sys", "zlib"],
+               "png": ["off", "sys", "libpng"],
+               "jpeg": ["off", "sys", "libjpeg", "libjpeg-turbo", "mozjpeg"],
+               "tiff": ["off", "sys", "libtiff"],
+               "expat": ["off", "sys", "expat"],
+               "secretstore": [True, False],
+               "aui": [True, False],
+               "opengl": [True, False],
+               "html": [True, False],
+               "mediactrl": [True, False],  # disabled by default as wxWidgets still uses deprecated GStreamer 0.10
+               "propgrid": [True, False],
+               "debugreport": [True, False],
+               "ribbon": [True, False],
+               "richtext": [True, False],
+               "sockets": [True, False],
+               "stc": [True, False],
+               "webview": [True, False],
+               "xml": [True, False],
+               "xrc": [True, False],
+               "cairo": [True, False],
+               "help": [True, False],
+               "html_help": [True, False],
+               "url": [True, False],
+               "protocol": [True, False],
+               "fs_inet": [True, False],
+               "custom_enables": ["ANY"], # comma splitted list
+               "custom_disables": ["ANY"]}
+    default_options = {
+               "shared": False,
+               "fPIC": True,
+               "unicode": True,
+               "compatibility": "3.0",
+               "zlib": "zlib",
+               "png": "libpng",
+               "jpeg": "libjpeg",
+               "tiff": "libtiff",
+               "expat": "expat",
+               "secretstore": True,
+               "aui": True,
+               "opengl": True,
+               "html": True,
+               "mediactrl": False,
+               "propgrid": True,
+               "debugreport": True,
+               "ribbon": True,
+               "richtext": True,
+               "sockets": True,
+               "stc": True,
+               "webview": True,
+               "xml": True,
+               "xrc": True,
+               "cairo": True,
+               "help": True,
+               "html_help": True,
+               "url": True,
+               "protocol": True,
+               "fs_inet": True,
+               "custom_enables": "",
+               "custom_disables": ""
+    }
+
+    _cmake = None
+
+    def config_options(self):
+        if self.settings.os == 'Windows':
+            del self.options.fPIC
+        if self.settings.os != 'Linux':
+            del self.options.cairo
+
     def source(self):
         get(
             self, 
@@ -27,8 +100,7 @@ class wxWidgetsConan(ConanFile):
         cmake_layout(self, build_folder="build_subforlder")
 
     def build(self):
-        cmake = CMake(self)
-        cmake.configure()
+        cmake = self._configure_cmake()
 
         # wxWidgets CMake use $<CONFIG> generator expressions
         # when configuring include directories (e.g. mswu and mswud), 
@@ -39,10 +111,86 @@ class wxWidgetsConan(ConanFile):
         cmake.build(build_type="Release")
 
     def package(self):
-        cmake = CMake(self)
+        cmake = self._configure_cmake()
         cmake.install(build_type="Debug")
         cmake.install(build_type="Release")
 
     def package_info(self):
         self.cpp_info.set_property("cmake_find_mode", "none")
         self.cpp_info.builddirs.append(os.path.join("lib", "cmake", "wxWidgets"))
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+
+        cmake = CMake(self)
+
+        # generic build options
+        variables = {
+            'wxBUILD_SHARED' : self.options.shared,
+            'wxBUILD_SAMPLES' : 'OFF',
+            'wxBUILD_TESTS' : 'OFF',
+            'wxBUILD_DEMOS' : 'OFF',
+            'wxBUILD_INSTALL' : True,
+            'wxBUILD_COMPATIBILITY' : self.options.compatibility,
+        }
+        if self.settings.compiler == 'clang':
+            variables['wxBUILD_PRECOMP'] = 'OFF'
+
+        # platform-specific options
+        if self.settings.compiler == 'msvc':
+            variables['wxBUILD_USE_STATIC_RUNTIME'] = 'MT' in str(self.settings.compiler.runtime)
+            variables['wxBUILD_MSVC_MULTIPROC'] = True
+        if self.settings.os == 'Linux':
+            # TODO : GTK3
+            # cmake.definitions['wxBUILD_TOOLKIT'] = 'gtk3'
+            variables['wxUSE_CAIRO'] = self.options.cairo
+        # Disable some optional libraries that will otherwise lead to non-deterministic builds
+        if self.settings.os != "Windows":
+            variables['wxUSE_LIBSDL'] = 'OFF'
+            variables['wxUSE_LIBICONV'] = 'OFF'
+            variables['wxUSE_LIBNOTIFY'] = 'OFF'
+            variables['wxUSE_LIBMSPACK'] = 'OFF'
+            variables['wxUSE_LIBGNOMEVFS'] = 'OFF'
+
+        variables['wxUSE_LIBPNG'] = 'sys' if self.options.png != 'off' else 'OFF'
+        variables['wxUSE_LIBJPEG'] = 'sys' if self.options.jpeg != 'off' else 'OFF'
+        variables['wxUSE_LIBTIFF'] = 'sys' if self.options.tiff != 'off' else 'OFF'
+        variables['wxUSE_ZLIB'] = 'sys' if self.options.zlib != 'off' else 'OFF'
+        variables['wxUSE_EXPAT'] = 'sys' if self.options.expat != 'off' else 'OFF'
+
+        # wxWidgets features
+        variables['wxUSE_UNICODE'] = self.options.unicode
+        variables['wxUSE_SECRETSTORE'] = self.options.secretstore
+
+        # wxWidgets libraries
+        variables['wxUSE_AUI'] = self.options.aui
+        variables['wxUSE_OPENGL'] = self.options.opengl
+        variables['wxUSE_HTML'] = self.options.html
+        variables['wxUSE_MEDIACTRL'] = self.options.mediactrl
+        variables['wxUSE_PROPGRID'] = self.options.propgrid
+        variables['wxUSE_DEBUGREPORT'] = self.options.debugreport
+        variables['wxUSE_RIBBON'] = self.options.ribbon
+        variables['wxUSE_RICHTEXT'] = self.options.richtext
+        variables['wxUSE_SOCKETS'] = self.options.sockets
+        variables['wxUSE_STC'] = self.options.stc
+        variables['wxUSE_WEBVIEW'] = self.options.webview
+        variables['wxUSE_XML'] = self.options.xml
+        variables['wxUSE_XRC'] = self.options.xrc
+        variables['wxUSE_HELP'] = self.options.help
+        variables['wxUSE_WXHTML_HELP'] = self.options.html_help
+        variables['wxUSE_URL'] = self.options.protocol
+        variables['wxUSE_PROTOCOL'] = self.options.protocol
+        variables['wxUSE_FS_INET'] = self.options.fs_inet
+
+        for item in str(self.options.custom_enables).split(","):
+            if len(item) > 0:
+                variables[item] = True
+        for item in str(self.options.custom_disables).split(","):
+            if len(item) > 0:
+                variables[item] = False
+
+        cmake.configure(variables=variables)
+
+        self._cmake = cmake
+        return self._cmake

--- a/recipes/wxwidgets/3.2.1/conanfile.py
+++ b/recipes/wxwidgets/3.2.1/conanfile.py
@@ -1,0 +1,48 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import cmake_layout, CMake
+from conan.tools.files import get
+
+
+class wxWidgetsConan(ConanFile):
+    name = "wxwidgets"
+    description = "wxWidgets is a C++ library that lets developers create applications for Windows, macOS, " \
+                  "Linux and other platforms with a single code base."
+    topics = ("conan", "wxwidgets", "gui", "ui")
+    url = "https://github.com/bincrafters/conan-wxwidgets"
+    homepage = "https://www.wxwidgets.org"
+    license = "wxWidgets"
+    generators = "CMakeDeps", "CMakeToolchain"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def source(self):
+        get(
+            self, 
+            **self.conan_data["sources"][self.version], 
+            strip_root=True, 
+        )
+
+    def layout(self):
+        cmake_layout(self, build_folder="build_subforlder")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+
+        # wxWidgets CMake use $<CONFIG> generator expressions
+        # when configuring include directories (e.g. mswu and mswud), 
+        # thus if only build/install Debug, CMake will complain for missing
+        # Release folder (e.g. mswu); if only build/install Release, CMake
+        # will complain for missing Debug folder (e.g. mswud).
+        cmake.build(build_type="Debug")
+        cmake.build(build_type="Release")
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install(build_type="Debug")
+        cmake.install(build_type="Release")
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_find_mode", "none")
+        self.cpp_info.builddirs.append(os.path.join("lib", "cmake", "wxWidgets"))

--- a/recipes/wxwidgets/3.2.1/test_package/CMakeLists.txt
+++ b/recipes/wxwidgets/3.2.1/test_package/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+find_package(wxWidgets REQUIRED core base xml CONFIG)
+
+if(MSVC)
+  add_definitions("-DUNICODE")
+  add_definitions("-D_UNICODE")
+  add_definitions("-D_CRT_SECURE_NO_WARNINGS")
+endif()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+
+target_link_libraries(${PROJECT_NAME} ${wxWidgets_LIBRARIES})

--- a/recipes/wxwidgets/3.2.1/test_package/CMakeLists.txt
+++ b/recipes/wxwidgets/3.2.1/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
-find_package(wxWidgets REQUIRED core base xml CONFIG)
+find_package(wxWidgets REQUIRED core base stc xml CONFIG)
 
 if(MSVC)
   add_definitions("-DUNICODE")

--- a/recipes/wxwidgets/3.2.1/test_package/conanfile.py
+++ b/recipes/wxwidgets/3.2.1/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure(cli_args=["--debug-output"])
+        print(f"!!! {self.settings.get_safe('build_type')}")
+        cmake.build()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/wxwidgets/3.2.1/test_package/test_package.cpp
+++ b/recipes/wxwidgets/3.2.1/test_package/test_package.cpp
@@ -1,0 +1,27 @@
+#include <cstdlib>
+#include <iostream>
+#include <wx/utils.h>
+#include <wx/init.h>
+#if wxUSE_STC
+#include <wx/stc/stc.h>
+#endif
+
+int main()
+{
+    int argc = 0;
+    wxChar * argv[] = {NULL};
+    if (!wxEntryStart(argc, argv)) {
+        std::cerr << "wxEntryStart failed!" << std::endl;
+        return EXIT_FAILURE;
+    }
+    wxVersionInfo vi = wxGetLibraryVersionInfo();
+    std::cout << "wxWidgets version: ";
+    std::cout << vi.GetMajor() << ".";
+    std::cout << vi.GetMinor() << ".";
+    std::cout << vi.GetMicro() << std::endl;
+#if wxUSE_STC
+    wxStyledTextCtrl * stc = new wxStyledTextCtrl();
+#endif
+    wxEntryCleanup();
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Description

Add Conan2 recipe for wxWidgets v3.2.1.

## Related Issue

[#20092](https://github.com/conan-io/conan-center-index/issues/20092)

## Motivation and Context

To be able to use wxWidgets v3.2.1 with Conan2.

## How Has This Been Tested?

Ran following commands:
* conan create . --build missing --version 3.2.1
* conan test test_package wxwidgets/3.2.1

On Windows 11 machine with Visual Studio 2022.
